### PR TITLE
主要修复了规则配置的一些问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ test/
 main
 
 test
+
+nohup.out
+repos/
+x-patrol

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -15,3 +15,6 @@ USER = xsec
 PASSWD = x@xsec.io
 SSL_MODE = disable
 PATH = data
+
+[search]
+MONTHS = 2

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -163,7 +163,7 @@ func DoSearch(reposConfig []models.RepoConfig, rules models.Rules) (map[string]*
 		} else {
 			// when rules.Part in ("filename", "path", "extension"), only search filename, and set rules.Pattern = "\\."
 			opts.FileRegexp = rules.Pattern
-			rules.Pattern = "\\."
+			rules.Pattern = "."
 		}
 
 		var filesOpened int

--- a/templates/rules_edit.html
+++ b/templates/rules_edit.html
@@ -95,8 +95,9 @@
 
                                         <div class="col-sm-10">
                                             <select class="form-control" name="part">
-                                                <option value="keyword" selected>keyword</option>
-                                                <option value="github">github keyword</option>
+                                                <option value="keyword" selected>本地检测文件内容</option>
+                                                <option value="filename">本地检测文件名</option>
+                                                <option value="github">github搜索</option>
                                             </select>
                                         </div>
                                     </div>
@@ -127,9 +128,7 @@
                                         <label for="desc" class="col-sm-2 control-label">描述</label>
 
                                         <div class="col-sm-10">
-                                            <textarea name="desc" id="desc" class="form-control">
-                                            {{.rules.Description}}
-                                            </textarea>
+                                            <textarea name="desc" id="desc" class="form-control">{{.rules.Description}}</textarea>
                                         </div>
                                     </div>
                                     <div class="form-group">
@@ -156,6 +155,24 @@
         </section>
     </div>
 </div>
+
+<script type="text/javascript">
+function enableSelection(optionName, selectedValue){
+  options = document.getElementsByName(optionName)[0];
+  for(i = 0; i < options.length; i++){
+    console.log(options[i].value + "==" + selectedValue + "?")
+    if(options[i].value == selectedValue){
+      options[i].selected = true;
+      break;
+    }
+  }
+}
+
+enableSelection('part', {{.rules.Part}})
+enableSelection('type', {{.rules.Type}})
+enableSelection('status', {{.rules.Status}})
+
+</script>
 
 <!-- jQuery 2.2.3 -->
 <script src="/lib/jQuery/jquery-2.2.3.min.js"></script>


### PR DESCRIPTION
1.修改规则的时候找不到本地文件名选项，已经修复。
2.修改规则的时候所有下拉框会被重置，已经修复。
3.文件名匹配的时候需要文件中存在英文句号，已经修复。
4.规则描述前面会有空格，已经修复。
5.把扫描的月份配置化。增加友好性。